### PR TITLE
Kleine Anpassung für Konformität mit IsyFact-Detailkonzept Datenzugriff

### DIFF
--- a/src/main/java/de/msg/terminfindung/persistence/entity/Zeitraum.java
+++ b/src/main/java/de/msg/terminfindung/persistence/entity/Zeitraum.java
@@ -25,8 +25,8 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 
 /**
@@ -43,7 +43,7 @@ public class Zeitraum extends AbstraktEntitaet {
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "zeitraum_id")
-    private List<TeilnehmerZeitraum> teilnehmerZeitraeume = new ArrayList<>();
+    private Set<TeilnehmerZeitraum> teilnehmerZeitraeume = new HashSet<>();
 
     public Zeitraum() {
     }
@@ -60,11 +60,11 @@ public class Zeitraum extends AbstraktEntitaet {
         this.beschreibung = beschreibung;
     }
 
-    public List<TeilnehmerZeitraum> getTeilnehmerZeitraeume() {
+    public Set<TeilnehmerZeitraum> getTeilnehmerZeitraeume() {
         return teilnehmerZeitraeume;
     }
 
-    public void setTeilnehmerZeitraeume(List<TeilnehmerZeitraum> teilnehmerZeitraeume) {
+    public void setTeilnehmerZeitraeume(Set<TeilnehmerZeitraum> teilnehmerZeitraeume) {
         this.teilnehmerZeitraeume = teilnehmerZeitraeume;
     }
 

--- a/src/test/java/de/msg/terminfindung/gui/awkwrapper/AwkWrapperTest.java
+++ b/src/test/java/de/msg/terminfindung/gui/awkwrapper/AwkWrapperTest.java
@@ -50,10 +50,7 @@ import java.util.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.anyListOf;
-import static org.mockito.Mockito.anyMapOf;
 import static org.mockito.Mockito.*;
 
 /**
@@ -227,7 +224,11 @@ public class AwkWrapperTest {
         assertEquals("Teilnehmer3", teilnehmer.get(2).getName());
 
         List<Tag> tage = tf.getTermine();
-        assertEquals("Teilnehmer1", tage.get(0).getZeitraeume().get(0).getTeilnehmerZeitraeume().get(0).getTeilnehmer().getName());
+        assertEquals(1, tage.get(0).getZeitraeume().get(0).getTeilnehmerZeitraeume().size());
+
+        for (TeilnehmerZeitraum teilnehmerZeitraum : tage.get(0).getZeitraeume().get(0).getTeilnehmerZeitraeume()) {
+            assertEquals("Teilnehmer1", teilnehmerZeitraum.getTeilnehmer().getName());
+        }
     }
 
     private static Date parseDate(String dateAsString) {


### PR DESCRIPTION
Als Beispiel für Kapitel 5.2 1:n Assoziationen in der Regel als Set (ohne Reihenfolge) definieren.