### PR TITLE
Batch-Ergebnisprotokoll

### DIFF
--- a/src/main/java/de/msg/terminfindung/core/datenpflege/Datenpflege.java
+++ b/src/main/java/de/msg/terminfindung/core/datenpflege/Datenpflege.java
@@ -16,8 +16,9 @@ public interface Datenpflege {
      * stattgefunden haben.
      *
      * @param stichtag Stichtag
+     * @return Anzahl der gelöschten Terminfindungen.
      * @throws TerminfindungBusinessException falls das Datum ungültig ist.
      */
-    void loescheVergangeneTerminfindungen(Date stichtag) throws TerminfindungBusinessException;
+    int loescheVergangeneTerminfindungen(Date stichtag) throws TerminfindungBusinessException;
 
 }

--- a/src/main/java/de/msg/terminfindung/core/datenpflege/impl/AwfVergangeneTermineLoeschen.java
+++ b/src/main/java/de/msg/terminfindung/core/datenpflege/impl/AwfVergangeneTermineLoeschen.java
@@ -49,7 +49,7 @@ class AwfVergangeneTermineLoeschen {
      * @param stichtag Stichtag
      * @throws TerminfindungBusinessException falls das Datum ungültig ist.
      */
-    void loescheVergangeneTerminfindungen(Date stichtag) throws TerminfindungBusinessException {
+    int loescheVergangeneTerminfindungen(Date stichtag) throws TerminfindungBusinessException {
 
         if (stichtag == null) {
             throw new TerminfindungBusinessException(FehlerSchluessel.MSG_PARAMETER_UNGUELTIG, "stichtag", "null");
@@ -58,9 +58,13 @@ class AwfVergangeneTermineLoeschen {
             throw new TerminfindungBusinessException(FehlerSchluessel.MSG_PARAMETER_DATUM_ZUKUNFT, "stichtag", stichtag.toString());
         }
 
+        int anzahlGeloescht = 0;
         for (Terminfindung tf : terminfindungDao.sucheVor(stichtag)) {
             terminfindungDao.loesche(tf);
+            anzahlGeloescht++;
         }
+
+        return anzahlGeloescht;
     }
 
 }

--- a/src/main/java/de/msg/terminfindung/core/datenpflege/impl/AwfVergangeneTermineLoeschen.java
+++ b/src/main/java/de/msg/terminfindung/core/datenpflege/impl/AwfVergangeneTermineLoeschen.java
@@ -47,9 +47,10 @@ class AwfVergangeneTermineLoeschen {
      * stattgefunden haben.
      *
      * @param stichtag Stichtag
+     * @return Anzahl der gelöschten Terminfindungen.
      * @throws TerminfindungBusinessException falls das Datum ungültig ist.
      */
-    void loescheVergangeneTerminfindungen(Date stichtag) throws TerminfindungBusinessException {
+    int loescheVergangeneTerminfindungen(Date stichtag) throws TerminfindungBusinessException {
 
         if (stichtag == null) {
             throw new TerminfindungBusinessException(FehlerSchluessel.MSG_PARAMETER_UNGUELTIG, "stichtag", "null");
@@ -58,9 +59,13 @@ class AwfVergangeneTermineLoeschen {
             throw new TerminfindungBusinessException(FehlerSchluessel.MSG_PARAMETER_DATUM_ZUKUNFT, "stichtag", stichtag.toString());
         }
 
+        int anzahlGeloescht = 0;
         for (Terminfindung tf : terminfindungDao.sucheVor(stichtag)) {
             terminfindungDao.loesche(tf);
+            anzahlGeloescht++;
         }
+
+        return anzahlGeloescht;
     }
 
 }

--- a/src/main/java/de/msg/terminfindung/core/datenpflege/impl/DatenpflegeImpl.java
+++ b/src/main/java/de/msg/terminfindung/core/datenpflege/impl/DatenpflegeImpl.java
@@ -20,7 +20,7 @@ public class DatenpflegeImpl implements Datenpflege {
     }
 
     @Override
-    public void loescheVergangeneTerminfindungen(Date stichtag) throws TerminfindungBusinessException {
-        awfVergangeneTermineLoeschen.loescheVergangeneTerminfindungen(stichtag);
+    public int loescheVergangeneTerminfindungen(Date stichtag) throws TerminfindungBusinessException {
+        return awfVergangeneTermineLoeschen.loescheVergangeneTerminfindungen(stichtag);
     }
 }


### PR DESCRIPTION
Beispielhafte Verwendung eines Batch-Ergebnisprotokolls hinzugefügt. Ein Batch kann beim Abarbeiten ein Batch-Ergebnisprotokoll in Form einer XML-Datei erzeugen, dass Meldungen und Statistikeinträge enthält.